### PR TITLE
refactor: refactor bad smell UnnecessaryToStringCall

### DIFF
--- a/src/main/java/com/palantir/gradle/graal/BaseGraalCompileTask.java
+++ b/src/main/java/com/palantir/gradle/graal/BaseGraalCompileTask.java
@@ -182,7 +182,7 @@ public abstract class BaseGraalCompileTask extends DefaultTask {
             // delayed environment variable expansion via !
             cmdArgs.add("/V:ON");
             cmdArgs.add("/c");
-            cmdArgs.add("\"" + startCmd  + "\"");
+            cmdArgs.add("\"" + startCmd + "\"");
             spec.setExecutable("cmd.exe");
             spec.setArgs(cmdArgs);
         }

--- a/src/main/java/com/palantir/gradle/graal/BaseGraalCompileTask.java
+++ b/src/main/java/com/palantir/gradle/graal/BaseGraalCompileTask.java
@@ -182,7 +182,7 @@ public abstract class BaseGraalCompileTask extends DefaultTask {
             // delayed environment variable expansion via !
             cmdArgs.add("/V:ON");
             cmdArgs.add("/c");
-            cmdArgs.add("\"" + startCmd.toString() + "\"");
+            cmdArgs.add("\"" + startCmd  + "\"");
             spec.setExecutable("cmd.exe");
             spec.setArgs(cmdArgs);
         }


### PR DESCRIPTION
# Repairing Code Style Issues
<!-- laughing-train-refactor -->
## UnnecessaryToStringCall
The `toString()` method is not needed in cases the underlying method handles the conversion. Also calling toString() on a String is redundant. Removing them simplifies the code.
<!-- fingerprint:939647443 -->
# Repairing Code Style Issues
* UnnecessaryToStringCall (1)
